### PR TITLE
Try using full package URL as name for churchsuite library

### DIFF
--- a/default.json
+++ b/default.json
@@ -19,7 +19,7 @@
     {
       "automerge": true,
       "matchPackageNames": [
-        "churchsuite"
+        "https://github.com/whitkirkchurch/churchsuite-utilities.git"
       ]
     }
   ],


### PR DESCRIPTION
This matches the feedback in the Renovate log.