### PR TITLE
Add pinning range strategy

### DIFF
--- a/default.json
+++ b/default.json
@@ -23,6 +23,7 @@
     }
   ],
   "platformAutomerge": true,
+  "rangeStrategy": "pin",
   "timezone": "Europe/London",
   "vulnerabilityAlerts": {
     "addLabels": [


### PR DESCRIPTION
This tells Renovate to explicitly pin everything, rather than relying on ranges.